### PR TITLE
bugfix/flask-migrate-entrypoint:modified the dockerfile to include the e flask migrate and flask run in entrypoint.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get install -y python3 python3-pip
 WORKDIR /OMNIFY
 COPY . /OMNIFY
 RUN pip install  --break-system-packages -r requirements.txt
-RUN flask db upgrade
 ENV FLASK_RUN_HOST=0.0.0.0
-ENTRYPOINT [ "flask", "run" ]
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "Running DB migrations..."
+flask db upgrade
+
+echo "Starting the app..."
+exec flask run


### PR DESCRIPTION
modified the dockerfile to include the e flask migrate and flask run in entrypoint.sh script so that instead of calling the flask upgrade in docker file which was not working now we moved this command and also flask run command to shell script called entrypoint.sh and calling this shell script via the entrypoint in dockerfile